### PR TITLE
fix: typo

### DIFF
--- a/packages/main/samples/electron-store.ts
+++ b/packages/main/samples/electron-store.ts
@@ -10,7 +10,7 @@ import Store from 'electron-store'
 const store = new Store()
 ipcMain.handle(
   'electron-store',
-  async (_evnet, methodSign: string, ...args: any[]) => {
+  async (_event, methodSign: string, ...args: any[]) => {
     if (typeof (store as any)[methodSign] === 'function') {
       return (store as any)[methodSign](...args)
     }


### PR DESCRIPTION
Fixes typo in the `packages/main/samples/electron-store.ts` file :)